### PR TITLE
Add GKE creation via Terraform

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,8 @@
+# Setting up clusters via Terraform
+This folder supports setting up clusters with various cloud providers.
+
+## Table of Contents
+1. [Getting Started](#Getting-Started)
+
+### Getting Started
+You will need to be sure that you have Terraform installed on your client machine. Additionally, depending upon the cloud provider of interest, you will need to meet their pre-requisites as well.

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.36.1"
+    }
+  }
+}
+
+provider "google" {
+  credentials = file(var.credentials_file)
+  project = var.project_id
+  region  = var.region
+}
+
+resource "google_service_account" "google_service_account" {
+  account_id   = var.account_id
+  display_name = var.display_name
+}
+
+resource "google_container_cluster" "google_container_cluster" {
+  name                     = var.gke_cluster_name
+  location                 = var.region
+  remove_default_node_pool = true
+  initial_node_count       = var.node_count
+}
+
+resource "google_container_node_pool" "node_pool" {
+  name       = var.node_pool_name
+  location   = var.region
+  cluster    = google_container_cluster.google_container_cluster.name
+  node_count = 3
+
+  node_config {
+    preemptible  = true
+    machine_type = var.machine_type
+
+    service_account = google_service_account.google_service_account.email
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+  }
+}

--- a/terraform/gcp/outputs.tf
+++ b/terraform/gcp/outputs.tf
@@ -1,0 +1,3 @@
+output "endpoint" {
+  value = google_container_cluster.google_container_cluster.endpoint
+}

--- a/terraform/gcp/terraform.tfvars
+++ b/terraform/gcp/terraform.tfvars
@@ -1,0 +1,9 @@
+credentials_file = ""
+project_id       = ""
+region           = ""
+account_id       = ""
+display_name     = ""
+gke_cluster_name = ""
+node_count       = 3
+node_pool_name   = ""
+machine_type     = ""

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -1,0 +1,44 @@
+variable "credentials_file" {
+  description = "Path to the GCP credentials JSON file"
+  type        = string
+}
+
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+}
+
+variable "account_id" {
+  description = "Service account ID"
+  type        = string
+}
+
+variable "display_name" {
+  description = "Service account display name"
+  type        = string
+}
+
+variable "gke_cluster_name" {
+  description = "GKE cluster name"
+  type        = string
+}
+
+variable "node_count" {
+  description = "Number of nodes in the node pool"
+  type        = number
+}
+
+variable "node_pool_name" {
+  description = "Name of the node pool"
+  type        = string
+}
+
+variable "machine_type" {
+  description = "Machine type for the node pool"
+  type        = string
+}


### PR DESCRIPTION
### Description
Initial PR that adds Terraform support for creating a basic GKE cluster. Eventually, other providers such as EKS and AKS will be supported with potential testing scripts.